### PR TITLE
userDetails: Change message button label

### DIFF
--- a/data/resources/user-details.ui
+++ b/data/resources/user-details.ui
@@ -178,7 +178,7 @@
         </child>
         <child>
           <object class="GtkModelButton" id="messageButton">
-            <property name="text" translatable="yes">Message</property>
+            <property name="text" translatable="yes">Start Conversation</property>
             <property name="halign">fill</property>
             <property name="hexpand">True</property>
             <property name="visible">True</property>


### PR DESCRIPTION
right-click menu, changed 'message' to 'start conversation'
[Reference](https://bugzilla.gnome.org/show_bug.cgi?id=774212)